### PR TITLE
Make sure there are no None images; correct 1s

### DIFF
--- a/train_model.ipynb
+++ b/train_model.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,15 +29,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 39,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|███████████████████████████████████████████████████████████████████████████| 20481/20481 [01:16<00:00, 268.28it/s]\n",
-      "100%|███████████████████████████████████████████████████████████████████████████| 18874/18874 [01:02<00:00, 301.95it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████▉| 18843/18873 [00:47<00:00, 391.60it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "desktop.ini\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████████████████████| 18873/18873 [00:47<00:00, 397.61it/s]\n",
+      "100%|███████████████████████████████████████████████████████████████████████████| 20481/20481 [00:50<00:00, 402.35it/s]\n"
      ]
     },
     {
@@ -49,23 +65,27 @@
     }
    ],
    "source": [
+    "#Trying to troubleshoot\n",
     "# All images were resized to 150 X 150. This can be changed depending on how much RAM is available\n",
     "image_size = 150\n",
-    "\n",
     "# Converts training images to numpy arrays and preprocesses them\n",
     "def train_data():\n",
     "    train_data_bat = [] \n",
     "    train_data_no_bat=[]\n",
+    "    for image2 in tqdm(os.listdir(train_no_bat)): \n",
+    "        path = os.path.join(train_no_bat, image2)\n",
+    "        img2 = cv2.imread(path, cv2.IMREAD_GRAYSCALE) \n",
+    "        if img2 is None:\n",
+    "            print(image2)\n",
+    "        if img2 is not None:\n",
+    "            img2 = cv2.resize(img2, (image_size, image_size))\n",
+    "            train_data_no_bat.append(img2) \n",
+    "        \n",
     "    for image1 in tqdm(os.listdir(train_bat)): \n",
     "        path = os.path.join(train_bat, image1)\n",
     "        img1 = cv2.imread(path, cv2.IMREAD_GRAYSCALE) \n",
     "        img1 = cv2.resize(img1, (image_size, image_size))\n",
     "        train_data_bat.append(img1) \n",
-    "    for image2 in tqdm(os.listdir(train_no_bat)): \n",
-    "        path = os.path.join(train_no_bat, image2)\n",
-    "        img2 = cv2.imread(path, cv2.IMREAD_GRAYSCALE) \n",
-    "        img2 = cv2.resize(img2, (image_size, image_size))\n",
-    "        train_data_no_bat.append(img2) \n",
     "    \n",
     "    train_data= np.concatenate((np.asarray(train_data_bat),np.asarray(train_data_no_bat)),axis=0)\n",
     "    return train_data\n",
@@ -76,7 +96,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All images were resized to 150 X 150. This can be changed depending on how much RAM is available\n",
+    "#image_size = 150\n",
+    "\n",
+    "# Converts training images to numpy arrays and preprocesses them\n",
+    "#def train_data():\n",
+    "#    train_data_bat = [] \n",
+    "#    train_data_no_bat=[]\n",
+    "#    for image2 in tqdm(os.listdir(train_no_bat)): \n",
+    "#        path = os.path.join(train_no_bat, image2)\n",
+    "#        img2 = cv2.imread(path, cv2.IMREAD_GRAYSCALE) \n",
+    "#        img2 = cv2.resize(img2, (image_size, image_size))\n",
+    "#        train_data_no_bat.append(img2) \n",
+    "#    for image1 in tqdm(os.listdir(train_bat)): \n",
+    "#        path = os.path.join(train_bat, image1)\n",
+    "#        img1 = cv2.imread(path, cv2.IMREAD_GRAYSCALE) \n",
+    "#        img1 = cv2.resize(img1, (image_size, image_size))\n",
+    "#        train_data_bat.append(img1) \n",
+    "    \n",
+    "#    train_data= np.concatenate((np.asarray(train_data_bat),np.asarray(train_data_no_bat)),axis=0)\n",
+    "#    return train_data\n",
+    "\n",
+    "#train_data = train_data()\n",
+    "#print(\"Processed training data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,26 +137,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
     "o1 = np.ones(20481)\n",
-    "z1 = np.zeros(18874)\n",
+    "z1 = np.zeros(18872)\n",
     "Y_train = np.concatenate((o1, z1), axis=0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "X shape:  (39355, 150, 150)\n",
-      "Y shape:  (39355, 1)\n"
+      "X shape:  (39353, 150, 150)\n",
+      "Y shape:  (39353, 1)\n"
      ]
     }
    ],
@@ -117,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,19 +181,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "X train flatten (33451, 22500)\n",
-      "X test flatten (5904, 22500)\n",
-      "x train:  (22500, 33451)\n",
-      "x test:  (22500, 5904)\n",
-      "y train:  (1, 33451)\n",
-      "y test:  (1, 5904)\n"
+      "X train flatten (33450, 22500)\n",
+      "X test flatten (5903, 22500)\n",
+      "x train:  (22500, 33450)\n",
+      "x test:  (22500, 5903)\n",
+      "y train:  (1, 33450)\n",
+      "y test:  (1, 5903)\n"
      ]
     }
    ],
@@ -163,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -253,40 +304,8 @@
      "output_type": "stream",
      "text": [
       "Cost after iteration 0: nan\n",
-      "Cost after iteration 100: 0.331153\n",
-      "Cost after iteration 200: 0.299745\n",
-      "Cost after iteration 300: 0.282722\n",
-      "Cost after iteration 400: 0.271579\n",
-      "Cost after iteration 500: 0.263312\n",
-      "Cost after iteration 600: 0.256747\n",
-      "Cost after iteration 700: 0.251315\n",
-      "Cost after iteration 800: 0.246694\n",
-      "Cost after iteration 900: 0.242683\n",
-      "Cost after iteration 1000: 0.239148\n",
-      "Cost after iteration 1100: 0.235992\n",
-      "Cost after iteration 1200: 0.233146\n",
-      "Cost after iteration 1300: 0.230557\n",
-      "Cost after iteration 1400: 0.228185\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEWCAYAAAB8LwAVAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXxV9Z3/8dcnG2FL2AJCEhZZisgqAdx3W1xRC6KOVVs72mmttT46rf7amWl1ZtrRabWLnaqtXeyiQLVaUbEqalUEwr4vsiWsYQeBkOXz++Mc8JJeIOTek5sb3s/H4z6Se5bP/eQkuZ/7Pef7/R5zd0REROrKSHUCIiLSNKlAiIhIXCoQIiISlwqEiIjEpQIhIiJxqUCIiEhcWalOIFk6derkPXv2THUaIiJpZdasWVvdvSDeumZTIHr27ElpaWmq0xARSStmtvZo63SKSURE4lKBEBGRuFQgREQkLhUIERGJSwVCRETiUoEQEZG4VCBERCQuFYjjeGneBq59/H2qa2pTnYqISKNSgTiOFlkZzC3byTvLK1KdiohIo1KBOI6L+3emY+scJpaWpzoVEZFGpQJxHNmZGVw7rJA3l25m+8cHU52OiEijUYGoh3ElRVTVOH+Zsz7VqYiINBoViHrof0oeg4vymThLp5lE5OShAlFP44YXsWTjbhau35XqVEREGoUKRD1dM6SQnKwMJqkVISInCRWIespvlc2nB3ThL3PXU1ldk+p0REQipwJxAsaVFLNzXxVvLtmS6lRERCKnAnECzu3Tia75uUwsLUt1KiIikVOBOAGZGcb1ZxTyzvIKNu8+kOp0REQipQJxgsYOL6bW4fnZGhMhIs2bCsQJ6tWpNSN6tmfirDLcPdXpiIhERgWiAcYNL2ZVxcfMXrcz1amIiERGBaIBrhjclZbZmUyapYvVItJ8qUA0QJsWWVwxqCt/nbeR/Qc1JkJEmicViAYaV1LE3spqXlu0MdWpiIhEItICYWajzWyZma00s/vjrP+SmS0ws7lm9p6ZDQiXX2Zms8J1s8zs4ijzbIhRvTrQvUMr3SdCRJqtyAqEmWUCjwOXAwOAmw4VgBh/dPdB7j4UeBj4Ubh8K3C1uw8CbgOeiSrPhjIzxg4v4oOPtlG2fV+q0xERSbooWxAjgZXuvsrdDwLPAmNiN3D33TFPWwMeLp/j7hvC5YuAXDNrEWGuDfLZ4UWYoQn8RKRZirJAFAKx3XzKw2VHMLOvmNlHBC2Ie+LE+Swwx90rI8kyAYXtWnJO705MmlVOba3GRIhI8xJlgbA4y/7hXdTdH3f33sC3gO8cEcDsdOB/gLvivoDZnWZWamalFRUVSUj5xI0rKWL9zv18uGpbSl5fRCQqURaIcqA45nkRsOEo20JwCuraQ0/MrAh4AbjV3T+Kt4O7P+nuJe5eUlBQkISUT9xnTj+FtrlZutuciDQ7URaImUBfM+tlZjnAjcBLsRuYWd+Yp1cCK8Ll7YDJwAPu/n6EOSYsNzuTq4d049WFG9l9oCrV6YiIJE1kBcLdq4G7gSnAEmCCuy8yswfN7Jpws7vNbJGZzQXuI+ixRLhfH+Dfwi6wc82sc1S5Jmrc8CIOVNUyeb7GRIhI82HNZcK5kpISLy0tTclruzuXPfoueblZPP/lc1KSg4hIQ5jZLHcvibdOI6mTwMwYN7yI2et2snLL3lSnIyKSFCoQSXLdGYVkZpjGRIhIs6ECkSSd2+ZyYb8Cnp9dTnVNbarTERFJmApEEo0rKWbLnkr+vmJrqlMREUmYCkQSXdy/Mx1a5zBR94kQkWZABSKJcrIyuHZoIW8s3sKOjw+mOh0RkYSoQCTZuJIiDtbU8uLc9alORUQkISoQSXZa1zwGFuZp6g0RSXsqEBEYN7yYRRt2s3jD7uNvLCLSRKlARGDM0G7kZGboYrWIpDUViAi0a5XDZQO68OLcDRys1pgIEUlPKhARGVtSxPaPD/LW0s2pTkVEpEFUICJyft8CuuS1YGKpLlaLSHpSgYhIZoZx/RlFvL28gi17DqQ6HRGRE6YCEaFxw4uoqXVemK0xESKSflQgInRqQRuG92jPxFnlNJf7bojIyUMFImLjhhexcste5pbtTHUqIiInRAUiYlcO7kpudoZGVotI2lGBiFjb3GyuGNiVv87bwIGqmlSnIyJSbyoQjWBsSRF7DlQzZdGmVKciIlJvKhCN4MxeHSlq31JjIkQkrahANIKMDGPs8CLe/2gr5Tv2pTodEZF6UYFoJJ89owh3+PMsjYkQkfSgAtFIiju04uzeHZk0u4zaWo2JEJGmTwWiEY0rKaJs+36mr96e6lRERI5LBaIRjT69K21bZOk+ESKSFlQgGlHLnEyuGtKVVxdsYm9ldarTERE5JhWIRjZ2eDH7q2qYPH9DqlMRETkmFYhGdkb3dpxa0FpjIkSkyVOBaGRmxg0lxZSu3cGqir2pTkdE5KgiLRBmNtrMlpnZSjO7P876L5nZAjOba2bvmdmAmHUPhPstM7PPRJlnY7t+WCGZGcYkTeAnIk1YZAXCzDKBx4HLgQHATbEFIPRHdx/k7kOBh4EfhfsOAG4ETgdGAz8P4zULnfNyuaBfAc/PXk+NxkSISBMVZQtiJLDS3Ve5+0HgWWBM7AbuvjvmaWvg0LvlGOBZd69099XAyjBeszFueBGbdh/g7ysqUp2KiEhcURaIQiC2w395uOwIZvYVM/uIoAVxz4nsm84uOa0L7Vtl6z4RItJkRVkgLM6yfzif4u6Pu3tv4FvAd05kXzO708xKzay0oiK9PonnZGUwrqSYVxdspHSNRlaLSNMTZYEoB4pjnhcBx+r8/yxw7Yns6+5PunuJu5cUFBQkmG7ju+eSvhS1b8XXJ8xlz4GqVKcjInKEKAvETKCvmfUysxyCi84vxW5gZn1jnl4JrAi/fwm40cxamFkvoC8wI8JcU6JNiyweHT+E9Tv28+BfF6c6HRGRI0RWINy9GrgbmAIsASa4+yIze9DMrgk3u9vMFpnZXOA+4LZw30XABGAx8BrwFXdvlvfrHN6jA1++sA8TZ5Xz2sKNqU5HROQwc28e3SxLSkq8tLQ01Wk0SFVNLdf//APKd+xjyr3n0zkvN9UpichJwsxmuXtJvHUaSd0EZGdm8Oj4oeyvquGbf55PcynaIpLeVCCaiD6d2/D/rjiNt5dV8PsP16Y6HRERFYim5HNn9uCCfgX81ytL+EjzNIlIiqlANCFmxiNjB9MyO5OvPzeXqpraVKckIicxFYgmpnNeLt+/fhDzy3fxkzdXHH8HEZGIqEA0QaMHdmXs8CIen7qSWWs1ylpEUkMFoon6j6sH0K1dS77+3DzdnlREUkIFoolqm5vNo+OHUr5jHw9plLWIpIAKRBM2omcHvnRBb54rLWPKok2pTkdETjIqEE3cvZf2Y2BhHg88v4Atew6kOh0ROYmoQDRxOVkZPDZ+KB9XVvOtSRplLSKNRwUiDfTp3JYHLu/P1GUV/GH6ulSnIyInCRWINHHrWT05r28n/mvyElZplLWINAIViDSRkWH877ghtMjO0ChrEWkUKhBppEteLv993SDmle/ip2+tTHU6ItLMqUCkmSsGdeX6Mwp5fOpKZq/bkep0RKQZU4FIQ9+95nROycvl68/N5WONshaRiKhApKG8cJT1uu37+M/JGmUtItFQgUhTI3t14K7ze/OnGWX8bfHmVKcjIs2QCkQau++yfgzomsf9f55PxZ7KVKcjIs2MCkQay8nK4LEbh7Knspr7dS9rEUkyFYg0169LW+4f3Z83l27hTzPKUp2OiDQjKhDNwO1n9+TcPp146OXFrN76carTEZFmQgWiGTg0yjonKxhlXa1R1iKSBCoQzcQp+bn813UDmVu2k59N1ShrEUlcvQqEmT1Tn2WSWlcN7sZ1wwr56VsrmaNR1iKSoPq2IE6PfWJmmcDw5KcjifremGCU9X0T5rHvoEZZi0jDHbNAmNkDZrYHGGxmu8PHHmAL8GKjZCgnJC83mx/eMIQ12z7m2y8spKZWXV9FpGGOWSDc/fvu3hZ4xN3zwkdbd+/o7g80Uo5ygs48tSP3XdqPF+as515NDS4iDVTfU0wvm1lrADO7xcx+ZGY9jreTmY02s2VmttLM7o+z/j4zW2xm883szdiYZvawmS0ysyVm9hMzs3r/VMJXL+nLA5f356/zNnDn70rZf7Am1SmJSJqpb4H4P2CfmQ0BvgmsBX53rB3C6xSPA5cDA4CbzGxAnc3mACXuPhiYBDwc7ns2cA4wGBgIjAAuqGeuErrrgt58//pBvL28gtt+PYM9B6pSnZKIpJH6FohqD+ZxGAP82N1/DLQ9zj4jgZXuvsrdDwLPhvsf5u5T3X1f+PRDoOjQKiAXyAFaANmAZqRrgJtGducnNw5j9tod3PTUh2zbqzmbRKR+6lsg9pjZA8DngMlh6yD7OPsUArFzP5SHy47mDuBVAHefBkwFNoaPKe6+pJ65Sh1XD+nGU7eWsGLzXm54Yhobd+1PdUoikgbqWyDGA5XAF9x9E8Eb/SPH2SfeNYO4XWrM7Bag5FBMM+sDnEbQoigELjaz8+Psd6eZlZpZaUVFRT1/lJPTRf0788wdo9iyu5Kx/zeNNZqSQ0SOo14FIiwKfwDyzewq4IC7H/MaBEGLoTjmeRGwoe5GZnYp8G3gGnc/dP7jOuBDd9/r7nsJWhZnxsnrSXcvcfeSgoKC+vwoJ7WRvTrwpzvPZH9VDWN/MY0lG3enOiURacLqO5L6BmAGMA64AZhuZmOPs9tMoK+Z9TKzHOBG4KU6cYcBTxAUhy0xq9YBF5hZlpllE1yg1immJBhYmM+Eu84iO9MY/8Q0Zq3ViGsRia++p5i+DYxw99vc/VaCC9D/dqwd3L0auBuYQvDmPsHdF5nZg2Z2TbjZI0AbYKKZzTWzQwVkEvARsACYB8xz97+eyA8mR9encxsmfuksOrTO4ZZfTue9FVtTnZKINEFWn5vMmNkCdx8U8zyD4E170DF2a1QlJSVeWlqa6jTSypY9B7j1VzNYVfExP7lpGKMHnpLqlESkkZnZLHcvibeuvi2I18xsipndbma3A5OBV5KVoKRG57a5PHfnWQwszOPLf5jFpFnlqU5JRJqQ483F1MfMznH3fyW4VjAYGAJMA55shPwkYvmtsvn9F0dxTp9OfGPiPH79/upUpyQiTcTxWhCPAXsA3P15d7/P3b9O0Hp4LOrkpHG0ysnil7eVMPr0U/jeXxfz4zdW6P7WInLcAtHT3efXXejupUDPSDKSlGiRlcnPbh7G2OFFPPrGch56eQm1mglW5KSWdZz1ucdY1zKZiUjqZWVm8PBnB9M2N4un31/NngNVfP/6QWRl6saDIiej4xWImWb2z+7+VOxCM7sDmBVdWpIqGRnGv181gPyW2Tz2xgr2HKjmxzcNpUVWZqpTE5FGdrwCcS/wgpn9E58UhBKCSfSuizIxSR0z495L+5GXm82DLy/mi78t5YnPDadVzvH+XESkOTneDYM2u/vZwPeANeHje+5+Vjj9hjRjXzi3F4+MHcz7K7fyuV/NYNc+TRcucjKp10dCd59KMLuqnGTGlRTTNjeLe/40l/FPTuOZO0ZR0LZFqtMSkUagq49yXKMHduXp20ewdts+bnhiGuU79h1/JxFJeyoQUi/n9u3E7784im17Kxn3i2ms2Lwn1SmJSMRUIKTehvdoz3N3nUVVjXP1z97jmWlrNKBOpBlTgZATclrXPCbfcy4je3Xk315cxG2/nsnm3QdSnZaIREAFQk5Yl7xcfvv5ETx07UBmrN7GZx57l8nzN6Y6LRFJMhUIaRAz43Nn9mDyPefRo0MrvvLH2Xz9ubns2q+usCLNhQqEJKR3QRsm/cvZ3HtpX16at4HLH3uXD1bqBkQizYEKhCQsOzODey/tx/P/cja52Znc/MvpPPTyYg5U1aQ6NRFJgAqEJM2Q4nZMvuc8bj2rB796bzVX//Q9Fq7fleq0RKSBVCAkqVrmZPLgmIH89gsj2bW/iut+/j6PT11JjaYOF0k7KhASiQv6FTDl3vP59IBTeGTKMsY/MY112zQCWySdqEBIZNq3zuFnNw/jsfFDWbZ5D5f/+F2em7lOg+tE0oQKhETKzLh2WCFT7j2fIcXt+NafF/DPvyulYk9lqlMTkeNQgZBG0a1dS35/xyj+7aoBvLtiK6Mfe5fXF2nGeJGmTAVCGk1GhnHHub14+avn0iUvlzufmcW3Js1nb2V1qlMTkThUIKTR9evSlr985Ry+fGFvJs4q4/Ifv8vMNdtTnZaI1KECISmRk5XBN0f3Z8JdZ2EYNzwxjf95bSkHq2tTnZqIhFQgJKVKenbgla+dx/iSYv7v7Y8Y8/j7zC/fmeq0RAQVCGkC2rTI4gefHcxTt5ZQsecA1/zsfb727BzKtmvchEgqqUBIk3HZgC5M/caFfOWi3ry2cBOX/Ogdvv/KEs0QK5Ii1lwGLZWUlHhpaWmq05Ak2bhrPz98fTl/nl1OfstsvnpxXz53Zg9ysvSZRiSZzGyWu5fEWxfpf5uZjTazZWa20szuj7P+PjNbbGbzzexNM+sRs667mb1uZkvCbXpGmas0LV3zW/K/44Yw+avnMagwn4deXsylP3qHl+dv0EhskUYSWYEws0zgceByYABwk5kNqLPZHKDE3QcDk4CHY9b9DnjE3U8DRgJbospVmq4B3fJ45o5R/PYLI2mVk8ndf5zDdT//QN1iRRpBlC2IkcBKd1/l7geBZ4ExsRu4+1R3P3Ql8kOgCCAsJFnu/rdwu70x28lJ6IJ+BUy+5zweHjuYjbv2M+4X07jrmVJWVexNdWoizVaUBaIQKIt5Xh4uO5o7gFfD7/sBO83seTObY2aPhC0SOYllZhg3lBTz9jcu4huf7sd7K7by6Uff5d9fXMi2vZrbSSTZoiwQFmdZ3JPHZnYLUAI8Ei7KAs4DvgGMAE4Fbo+z351mVmpmpRUVFcnIWdJAy5xM7r64L2//60XcOLKYP0xfxwWPvM3jU1ey/6DuYieSLFEWiHKgOOZ5EbCh7kZmdinwbeAad6+M2XdOeHqqGvgLcEbdfd39SXcvcfeSgoKCpP8A0rQVtG3Bf147iCn3ns9ZvTvyyJRlXPzDt5k0q1w3KBJJgigLxEygr5n1MrMc4EbgpdgNzGwY8ARBcdhSZ9/2ZnboXf9iYHGEuUoa69O5DU/dWsJzd55J57Yt+MbEeVz10/f4+wq1KkUSEVmBCD/53w1MAZYAE9x9kZk9aGbXhJs9ArQBJprZXDN7Kdy3huD00ptmtoDgdNVTUeUqzcOoUzvywpfP4Sc3DWPPgSo+96sZ3Pb0DJZu2p3q1ETSkgbKSbNUWV3D7z5Yy0/fWsHeymrGDi/ivss+xSn5ualOTaRJOdZAORUIadZ27jvIz95aye+mrSUjA24c0Z07zu1FcYdWqU5NpElQgZCTXtn2fTz2xgpemreemlrnikFduev83gwqyk91aiIppQIhEtq4az+/eX8Nf5y+jj2V1Zx1akfuvOBULuxXgFm8ntkizZsKhEgduw9U8eyMdTz93ho27T5Avy5t+OfzTmXM0EJNCCgnFRUIkaM4WF3Ly/M38OS7q1i6aQ9d8lrw+XN6cfOo7uTlZqc6PZHIqUCIHIe78+6KrTz57ke8v3IbbVpkceOIYr5wbi+6tWuZ6vREIqMCIXICFq7fxZPvrmLygo0YcPWQbvzzeacyoFteqlMTSToVCJEGKN+xj6ffW8OzM9ex72AN5/XtxF3n9+acPh11QVuaDRUIkQTs2lfF76ev5TcfrKFiTyUDuuZx5/mncuXgrmRn6oK2pDcVCJEkqKyu4cU5G3jy76tYuWUvhe1a8vlzenLjyO60aZGV6vREGkQFQiSJamudqcu28OS7q5i+ejttc7O4eVR3/mlkD7p31AhtSS8qECIRmVu2k6feXcWrCzdS63B2746MH1HMZ04/hdxs3eNKmj4VCJGIbdy1n0ml5UyYVUbZ9v3kt8zm2qHdGD+iu3o/SZOmAiHSSGprnWmrtvHczDJeW7SJg9W1DCrM54YRxVwzpBv5LTX4TpoWFQiRFNi57yB/mbOeZ2eWsXTTHnKzM7hiYFduGFHMqF4d1FVWmgQVCJEUcncWrN/FczPLeGnuBvZUVtOrU2vGlRQx9owiOufpHhWSOioQIk3E/oM1vLJgI8+VljFj9XYyM4yLPtWZ8SOKuehTBWRpXIU0MhUIkSZoVcVeJpSWM2lWOVv3VtK5bQs+O7yIG0qK6dWpdarTk5OECoRIE1ZVU8vUpVuYUFrGW0u3UOswqlcHbhxZzOUDu6q7rERKBUIkTWzefYBJs8qZUFrG2m37aJubxTVDunH1kG6M6NmBzAxd2JbkUoEQSTO1tc701duZUFrGqws3cqCqls5tW3DFoK5cObgrw7u3J0PFQpJABUIkje07WM2bS7Ywef5Gpi7bQmV1LV3ygmJx1eCuDCtWsZCGU4EQaSb2Vlbz5pLNTJ6/kbeXV3CwupZu+bmHWxZDi9tpfIWcEBUIkWZoz4Eq3giLxTvLK6iqcQrbteSqwUGxGFSYr2Ihx6UCIdLM7dpfxRuLN/Py/A38fcVWqmud4g4tuXJQN64a3JXTu+WpWEhcKhAiJ5Fd+6qYsngTk+dv5P2VQbHo2bEVVw7uypWDunFa17YqFnKYCoTISWrHxweZsmgTkxds5IOPtlFT65xa0JqrBnXlysHd6NeljYrFSU4FQkTYtreSKYuC01AfrtpGrcOpBa259LQuXNy/M8N7tNctVE9CKhAicoSKPZW8tnAjry/ezPRV2zlYU0tebhYXfKozl/TvzAX9CmjfOifVaUojSFmBMLPRwI+BTOCX7v6DOuvvA74IVAMVwBfcfW3M+jxgCfCCu999rNdSgRBpmL2V1by3YitvLd3MW0sr2Lq3kgyD4T3ac3H/LlxyWmf6dtapqOYqJQXCzDKB5cBlQDkwE7jJ3RfHbHMRMN3d95nZvwAXuvv4mPU/BgqA7SoQItGrrQ2mJn9z6RbeXLKZRRt2A1DUviWX9O/Mxad1YVSvDpofqhk5VoHIivB1RwIr3X1VmMSzwBjgcIFw96kx238I3HLoiZkNB7oArwFxkxeR5MrIMIYUt2NIcTvuu6wfm3Yd4K2lW3hr6WaeKy3jt9PW0ionk3P7dOKS0zpz0ac6634WzViUBaIQKIt5Xg6MOsb2dwCvAphZBvBD4HPAJVElKCLHdkp+LjeP6s7No7pzoKqGaR9t482lm3lryRZeX7wZgCFF+YdPRWm8RfMSZYGI91cS93yWmd1C0Eq4IFz0ZeAVdy871h+bmd0J3AnQvXv3hJIVkWPLzc7kov6duah/Z3yMs3TTHt4KT0U99uZyHn1jOV3yWnBx/85c3L8LZ/fuSOsWUb7FSNSivAZxFvBdd/9M+PwBAHf/fp3tLgV+Clzg7lvCZX8AzgNqgTZADvBzd7//aK+naxAiqbNtbyVvL6vgraVbeGd5BXsrq8nONIZ1b8+5fTpxTp+ODC5qp260TVCqLlJnEVykvgRYT3CR+mZ3XxSzzTBgEjDa3VccJc7tQIkuUoukh4PVtcxcs52/r9jK+yu3snDDLtyhTYsszjy1A+f06cS5fTrRRz2jmoSUXKR292ozuxuYQtDN9Wl3X2RmDwKl7v4S8AhBC2Fi+Ieyzt2viSonEYleTlYG5/TpxDl9OgHBaO5pq7bx3sqgYLyxZAsAndu24Nw+nTg7bGF0zW+ZyrQlDg2UE5FGVbZ9Hx98tJX3Vm7jg5Vb2fbxQQB6F7QOT0d14szeHcnLzU5xpicHjaQWkSaptja42P3+yq28t3IrM1ZvZ39VDRkGg4vaHS4YZ/RoR4ssjb2IggqEiKSFg9W1zFm343DBmFe+i5paJzc7g5G9OnJO746c06cTA7rm6S56SaICISJpafeBKqav2n64YKzcsheA/JbZlPRoz4heHRjRswODCvPJyVIPqYZI1UhqEZGE5OVmc9mALlw2oAsAm3Yd4IOPtjJ91XZmrtnOm0uDC9652RkMKw4KxsieHTijRzta5ejtLVFqQYhI2qrYU0npmu1MXx0UjCUbd1PrkJlhDCzMZ2TP9ozoGbQyNDttfDrFJCInhT0Hqpi1dgcz12xn5uodzC3bycGaWgD6dWnDiJ4dGBmelurWTt1qQQVCRE5SB6pqmF++i5lrtjNj9XZmrd3B3spqAArbtWRUrw6Hr2P0Lmh9Ug7cU4EQEQFqap0lG3czIzwlNXPNdrbuDcZhdGydQ0nP9gzv0Z5h3dszsFs+LXOaf9daFQgRkTjcndVbPw5bGMGpqXXb9wGQlWH079qWYcXtGda9HcO6t6dnx1bNrpWhAiEiUk9b91Yyd91O5pQF1zDmle06fFqqXatshha3Y1hxe4Z2b8fQonbkt0rvEd/q5ioiUk+d2rTg0gFduDTsWltT66zcspe5ZTuYs24nc9bt5J3lyzn02bp3QWuGHm5ltONTXdqS1UxmrVULQkTkBO05UMWC8l3MKdvJnHVB4Tg0p1TL7EwGFeUHBaM4ODXVpQnfdU8tCBGRJGqbm83Z4Uy0EFzLKN+xn9lhsZhbtpOn31tNVU3wAbxbfi5Du7djUGE7BhXmM6gwPy1OTalAiIgkyMwo7tCK4g6tGDO0EAi62C7euDu8nhG0NF5ZsOnwPsUdWjKoMJ+BYcEYVJhPu1ZNazCfCoSISARyszM5o3t7zuje/vCyHR8fZOGGXSxYv4uF64OvsUWjqP0/Fo1UjgBXgRARaSTtW+dwXt8CzutbcHjZzn0HWbh+9xFF49WFnxSNwnZB0RhU9Enh6NBIRUMFQkQkhdq1yuHcvp04t2+nw8t27as63NI4VDheW3Rk0RhYmHdEa6NjmxZJz00FQkSkiclvlX3EbVsBdu2vYtGGQ62M3Sxcv4spizYfXv/q187jtK55Sc1DBUJEJA3kt8zm7N6dOLv3J0Vj94EqFoXFondBm6S/pgqEiEiaysvN5qzeHTmrd8dI4jeP4X4iIpJ0KhAiIhKXCoSIiMSlAiEiInGpQIiISFwqECIiEpcKhIiIxKUCISIicTWbGwaZ2R5gWdcAvtQAAA3RSURBVEThOwFbFVuxUxBXsRU76rg93L0g3ormNJJ62dHuipQoMytVbMVORVzFVuxUxtUpJhERiUsFQkRE4mpOBeJJxVbsFMZOx5wVu/nEjiRus7lILSIiydWcWhAiIpJEKhAiIhJX2nZzNbP+wBigEHBgA/CSuy9JaWJNgJl1ANzdd6RDXIlPx1tSLS1bEGb2LeBZwIAZwMzw+z+Z2f2pzK0+zKyLmZ1hZsPMrEuSYnY3s2fNrAKYDsw0sy3hsp5NLW6c10n6MYkyblSxG+N4R3lMpHlJy4vUZrYcON3dq+oszwEWuXvfJLxGF2JaJ+6++Ti71CfmUOAXQD6wPlxcBOwEvuzusxOIPQ14DJjk7jXhskxgHHCvu5/ZlOLGxI/kmER8rNPu9xh13mH8fGA0R7bqp7j7zkTihrEjO2MQcewoj0lksQ9z97R7AEsJhofXXd6DYER1IrGHAh8CS4A3wsfScNkZCcaeC4yKs/xMYF6CsVc0ZF2q4kZ9TCI+1mn3e2yEvG8FPgL+D/hO+PhFuOzWBGN/K8z9fuCW8HH/oWVNOHaUxySy2LGPdG1BjAZ+BqwAysLF3YE+wN3u/loCsecCd7n79DrLzwSecPchCcRe4Udp3ZjZSnfvk0DsZ4HtwG/55JgUA7cBndz9hqYUNyZ+JMck4mOddr/HMHaUeS8jKD476yxvD0x3934JxI7sjEHEsaM8JpHFjpWWF6nd/TUz6weMJGheGVAOzPSwWZ6A1nWLQ/iaH5pZ6wRjv2pmk4HfceQ//61Ag4ta6FbgDuB7HHlMXgJ+1QTjHhLVMYnyWKfj7xGizdsITnPUVRuuS0Qt0A1YW2d513BdU40d5TGJMvYnL5KOLYgomdlPgN7E/yda7e53Jxj/cj4533n4n9/dX0kkbjqL6phEeazT9fcY4bG+Dfh34HWObNVfBjzk7r9JIHaUZwyijB3lMYks9hGvowLxj9Lxn9/Msgg+eV7LkRetXgR+VbcJneq4El86H+/w9MZnOPL/ZoonoZuumWUQzRmDqGNHeUwii334NVQgGk/Y6+ABguLTOVy8heCf/wd1zyeeYOw/EfRG+S3BHwoEPVRuAzq4+/imFDcmfiTHJOJjnXa/x6jzjnmNpPf+C+Man7yJHyqaMzwJb2BRxg7jR3JMoo4NKhD/IOJ//inAW8Bv3X1TuOwU4HbgEne/LIHYy9z9U0dZt7yhF62iihsTI5JjEvGxTrvfY7h/lHnHdqEtJ/hEm6yuv58Gfk5wGii2e26fMPbrTTR2lMcksthHSFZ3qObyAKYQdH07JWbZKQRd3/6WYOyjdsE91rp6xv6QoK98RsyyDGA8Qa+GJhU36mMS8bFOu99jI+QdZRfaJUDPOMt7AUuacOy07God+0jLkdQR6+nu/+PhJywAd9/k7j8guAiUiLVm9s3Y0avhqNZv8cmFpoa6ERgLbDKz5WH3vU3A9eG6RONuDuOuSFLcQ6I6JlEe63T8PUK0eR+19x+QaO+/LD453RZrPZDdhGNHeUyijH1YWnZzjdhaM/smQTN8Mxw+z3c7if8TjSdoibwTxnRgM0EXxoTGE7j7GjP7EfBDgsEypxF8mljs7qsTiRvmjZl1JGjKPubutySSb4yojklkxzri2BuAV4BfArOBy4GzgUXEfyM7EYfyfjumSCQr7yi70D5NMOXIs3Vi30jiXX+jjJ2uXa0P0zWIOsKeAfdz5DWIQ/9EP/AEewhYMKy/CPjQ3ffGLB/tiXWp+w+CN5Ms4G8EF93eAS4l6NnwXw2M+1KcxRcTnMvG3a9pUMJHf73zCHJf4Imd/x0FLHX3XWbWiuB3egbBG+1/u/uuBGLfA7zg7ol+YIgX+w8Ev8OWwC6CT4MvAJcQ/L/elmD8PsB1BG8m1cBy4E+JHI+Y2FF2Kz7tKLEXJyH2AOCaiGJfcZTYadHVWgXiBJjZ59391wnsfw/wFYLznkOBr7n7i+G62e5+RgKxF4QxWxCckihy991m1pLg3PXgBsadDSwm+ETrBH+IfyI83eHu7zQ05zD+DHcfGX7/RYLj8xfg08Bfw1N7DYm7CBji7tVm9iTwMfBngjfaIe5+fQI57wrjfQT8EZjo7lsbGq9O7PnuPjjs7roe6ObuNWFPm3kN/T2Gse8BrgLeBa4gOI+9g6BgfNnd3074B5CUMbPO7r4lqUGTdTHjZHgA6xLcfwHQJvy+J1BKUCQA5iQYe06878PncxOImwF8naBVMjRctiqJxzQ275lAQfh9a4JWREPjLon5fnayjsehnMPj8mmC0xAVBM3624C2CcZeCOQA7YE9BF1bAXJJ/KLpAiAz/L4V8Hb4ffck/P3lAz8g+PCzLXwsCZe1S9bfS5zXfTXB/fOA7wPPADfVWffzBGOfQjBX0uNAR+C7wHxgAtA1wdgd4jzWhH83HZJ1fHUNog4zm3+0VUCiUyNnenhayYNrBhcCk8ysB4kPjz9oZq3cfR8w/NDCsNtug6cMcPda4FEzmxh+3Uxyr11lhKf1MghatBXh635sZtUJxF0Y0+KbZ2Yl7l5qwRQtiQ428/C4vA68bmbZBKf3bgL+FyhIIPavCCaHzAS+DUw0s1UE15OeTSjrQBZQQ9DSbAvg7uvCnyEREwhOO17k/9iFdiLBCN8GMbOjtayNoNWciF8TdHH9M/AFMxsL3OzulQTHPBG/ASYTfNiZCvyBoAU3hqCL6pgEYm/lH6cHKSS4buXAqQnE/kRUlT1dHwTXG4YSzAwb++hJMBAlkdhvEX4Kj1mWRXChqSbB2C2OsrwTMCiJx+dKgnP4yYq3BlgFrA6/nhIub0NiLZ98gn/Qjwjuq1AVxn+H4BRTIjkf9dM20DIJx6QbwaklgHYEvZpGJiHu1wg+wT5JUIQ+Hy4vAN5NMHaUXWhrwv+dqXEe+xOMPbfO828D7xN84p+dYOzY1vG6Y71uA2J/g6DVOihm2epE/0bqPnQNog4z+xXwa3d/L866P7r7zQnELgKqPaYLbcy6c9z9/YbGbm7CC8tdPIEeWGGctgSfprKAck/OfT36ufvyROOkgpmdTtDDbaG7L01i3NcJpsaP1/vvMne/NIHYC4Hr3H1FnHVl7l6cQOwlBLO51sYsuw34JsHp4B4JxJ7n4ezPZvaf7v6dmHUL3H1QQ2OHMYqARwl6Mf0HwTWq5LQcDr2GCoSIJCrK3n/haZ8F7r4szrpr3f0vCcR+GHjd3d+os3w08FNPbLrvB4GHPaa3Yri8D8ExGdvQ2HXiXU3Q8unp7qckI+bh2CoQIhKlRHv/KXa94rUEerv7wmTGVoEQkUiZ2Tp3T3QWAsVOQWz1YhKRhEXZ+0+xGzd2LBUIEUmGLgT3Jqh7rcGADxQ7rWIfpgIhIsnwMkGvn7l1V5jZ24qdVrE/iaVrECIiEo+m+xYRkbhUIEREJC4VCEkLZuZm9sOY598ws+8mKfZvwsFYkTKzcWa2xMym1lneMxwtjJkNDaeIjjKPV8ysXZSvIc2DCoSki0rgejPrlOpEYplZ5glsfgfBtNoXHWOboQRTcZ9IDvXqbGKBDHe/whO4t7qcPFQgJF1UE0wy9/W6K+q2AMxsb/j1QjN7x8wmWHD7zh+Y2T+Z2QwzW2BmvWPCXGpmfw+3uyrcP9PMHjGzmWY238zuiok71cz+SDCFdt18bgrjLzSz/wmX/TtwLvALM3sk3g9oZjnAg8B4M5trZuPNrLWZPR3mMMfMxoTb3m5mE83srwQzyrYxszfNbHb42oe26xm2Wn5OMNNnsZmtOVRozey+MM+FZnZvnX2eMrNFZvZ6OFJXTjbJnv1PDz2ieAB7CebuX0MwU+s3gO+G634DjI3dNvx6IbAT6EowvfV64Hvhuq8R3Dr10P6vEXxg6ktwZ65c4E7gO+E2LQju39ErjPsx0CtOnt2AdQQzpGYRzEJ6bbjubaAkzj49CSbPg2Byu5/FrPtv4Jbw+3YEd4BrHW5Xzif3i8gC8sLvOwErCfrE9ySY7v3MmJhrwm2GExS41gSz5y4ChoX7VPPJ/T8mHMpBj5ProRaEpA13300wNfo9J7DbTHff6MH8/h8R3MMBgjfGnjHbTXD3Wg9mDF0F9Ce4IdCtZjaXYMrwjgQFBGCGx59pdgTBjXgq3L2a4B4A559AvnV9Grg/zOFtgsJ1aBqFv7n79vB7A/47HGH7BsG9AQ6NqF3rwc3s6zqX4NapH3swodzzwHnhutX+SR/7WRx5rOQkoYFykm4eIzhVEjsZWTXh6VIzM4I7sh1SGfN9bczzWo78+687IOjQ7VW/6u5TYldYcKOnj4+SX6I3fooX77NeZyZTC+65HZvDPxG0Woa7e5WZrSEoJjQw19jjVkNwj2w5yagFIWkl/MQ8geCC7yFr+OQuemOAhtwdbZyZZYTXJU4FlgFTgH+x8G5rZtbPzFofJ8504AIz6xRewL6J4CZF9bWH8E5voSnAV8PCh5kNO8p++cCWsDhcRHCTq+N5F7jWzFqFP9d1wN9PIFdp5lQgJB39kOAc+iFPEbwpzwDqfrKur2UEb+SvAl9y9wPAL4HFwOywG+oTHKfV7e4bgQcI7nY2j+CuZC+eQB5TgQGHLlIDDxEUvPlhDg8dZb8/ACVmVkrQmjjuzYDcfTbB9ZcZBIXtl+4+5wRylWZOU22IiEhcakGIiEhcKhAiIhKXCoSIiMSlAiEiInGpQIiISFwqECIiEpcKhIiIxKUCISIicf1/Sycd7KlLP9IAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test Accuracy: 90.94 %\n",
-      "Train Accuracy: 91.12 %\n"
+      "Cost after iteration 100: 0.329388\n",
+      "Cost after iteration 200: 0.297972\n"
      ]
     }
    ],
@@ -327,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There seemed to be some images that were "None" among the no bat training images. I found those images by printing them, and added a check that we only resize, etc. images that are not None. I also corrected the number of zeros -- this needed to be two less.  